### PR TITLE
Add base64 encoder/decoder

### DIFF
--- a/kxclib.ml
+++ b/kxclib.ml
@@ -1907,3 +1907,142 @@ module Jv = struct
       | None, _ -> jv)
     | jv -> jv
 end
+
+module Base64 = struct
+  open struct
+    let int_A = int_of_char 'A'
+    let int_Z = int_of_char 'Z'
+    let int_a = int_of_char 'a'
+    let int_z = int_of_char 'z'
+    let int_0 = int_of_char '0'
+    let int_9 = int_of_char '9'
+  end
+
+  let encode ?(no_padding=false) ?(c62='+') ?(c63='/') input =
+    let open Bytes in
+    let c62, c63 = int_of_char c62, int_of_char c63 in
+    let sixbit_to_char b =
+      if b < 26 (* A-Z *) then b + int_A
+      else if b < 52 (* a-z *) then b - 26 + int_a
+      else if b < 62 (* 0-9 *) then b - 52 + int_0
+      else if b = 62 then c62
+      else c63
+    in
+    let len = length input in
+    let estimated_chars = (len / 3) * 4 + 4 (* worst case *) in
+    let output = create estimated_chars in
+    let write i o len =
+      let set value o =
+        set_uint8 output o (sixbit_to_char (value land 0x3f));
+        o+1
+      in
+      let get i = get_uint8 input i in
+      let b1 = get i in
+      let o = o |> set (b1 lsr 2) in (* b1[0]..b1[5] *)
+      match len with
+      | `I -> o |> set (b1 lsl 4) (* b1[6] b1[7] 0 0 0 0 *)
+      | `S n ->
+        let b2 = get (i+1) in
+        let o = o |> set ((b1 lsl 4) lor (b2 lsr 4)) in (* b1[6] b1[7] b2[0]..b2[3] *)
+        match n with
+        | `I -> o |> set (b2 lsl 2) (* b2[4]..b2[7] 0 0*)
+        | `S `I ->
+          let b3 = get (i+2) in
+          o |> set ((b2 lsl 2) lor (b3 lsr 6)) (* b2[4]..b2[7] b3[0] b3[1]*)
+            |> set b3 (* b3[2]..b3[7] *)
+    in
+    let rec go i o =
+      match len - i with
+      | 0 ->
+        let pad_chars =
+          match o mod 4 with
+          | _ when no_padding -> 0
+          | 0 -> 0 (* when len mod 3 = 0 *)
+          | 2 -> 2 (* when len mod 3 = 1 *)
+          | 3 -> 1 (* when len mod 3 = 2 *)
+          | _ -> failwith "impossible"
+        in
+        List.range 0 pad_chars
+        |> List.fold_left (fun o _ -> set output o '='; o+1) o
+      | 1 -> `I |> write i o |> go (i+1)
+      | 2 -> `S `I |> write i o |> go (i+2)
+      | _ -> `S (`S `I) |> write i o |> go (i+3)
+    in
+    let actual_chars = go 0 0 in
+    Bytes.sub output 0 actual_chars |> Bytes.to_string
+
+  let decode ?(no_padding=false) ?(ignore_newline=false) ?(ignore_unknown=false) ?(c62='+') ?(c63='/') input =
+    let open Bytes in
+    let c62, c63 = int_of_char c62, int_of_char c63 in
+    let char_to_sixbit c =
+      if int_A <= c && c <= int_Z then Some (c - int_A)
+      else if int_a <= c && c <= int_z then Some (c - int_a + 26)
+      else if int_0 <= c && c <= int_9 then Some (c - int_0 + 52)
+      else if c = c62 then Some 62
+      else if c = c63 then Some 63
+      else None
+    in
+    let input = of_string input in
+    let len =
+      let len = length input in
+      if no_padding || (len mod 4) = 0 then len
+      else invalid_arg "Base64.decode: wrong padding"
+    in
+    let output =
+      let estimated_bytes = (len / 4) * 3 + 2 in  (* worst case: 3n+2 bytes (= 4n+3 chars) *)
+      create estimated_bytes
+    in
+    let read stack o =
+      let set o value = set_uint8 output o (value land 0xff); o+1 in
+      match List.rev stack with
+      | [] -> o
+      | [_] -> invalid_arg "Base64.decode: unterminated input"
+      | s1 :: s2 :: ss ->
+        let o = set o ((s1 lsl 2) lor (s2 lsr 4)) in (* s1[0]..s1[5] s2[0] s2[1] *)
+        match ss with
+        | [] -> (* [3n+1 bytes] 4bits = s2[2]..s2[5] should've been padded *)
+          if not ((s2 land 0xf) = 0) then invalid_arg "Base64.decode: unterminated input"
+          else o
+        | s3 :: ss ->
+          let o = set o ((s2 lsl 4) lor (s3 lsr 2)) in (* s2[2]..s1[5] s3[0]..[3] *)
+          match ss with
+          | [] -> (* [3n+2 bytes] 2bits = s3[4] s3[5] should've been padded *)
+            if not ((s3 land 0x3) = 0) then invalid_arg "Base64.decode: unterminated input"
+            else o
+          | s4 :: [] -> (* [3n bytes] *)
+            set o ((s3 lsl 6) lor s4) (* s3[4] s3[5] s4[0]..[5] *)
+          | _ -> failwith "impossible"
+    in
+    let rec go stack i o =
+      if i = len then read stack o
+      else
+        let c = get_uint8 input i in
+        match char_to_sixbit c with
+        | None ->
+          begin match char_of_int c with
+          | _ when ignore_unknown -> go stack (i+1) o
+          | '\r' | '\n' when ignore_newline -> go stack (i+1) o
+          | '=' when not no_padding ->
+            let rest = sub_string input i (len - i) in
+            if rest = "=" || rest = "==" then read stack o
+            else invalid_arg' "Base64.decode: invalid char '=' at index %d" i
+          | c -> invalid_arg' "Base64.decode: invalid char '%c' at index %d" c i
+          end
+        | Some s ->
+          let stack = s :: stack in
+          if List.length stack = 4 then
+            let o = read stack o in
+            go [] (i+1) o
+          else
+            go stack (i+1) o
+    in
+    let actual_bytes = go [] 0 0 in
+    Bytes.sub output 0 actual_bytes
+
+  let encode_rfc4648 = encode ~no_padding:false ~c62:'+' ~c63:'/'
+  let decode_rfc4648 = decode ~no_padding:false ~ignore_newline:false ~ignore_unknown:false ~c62:'+' ~c63:'/'
+
+  let encode_rfc4648_url ?(no_padding=false) = encode ~no_padding ~c62:'-' ~c63:'_'
+  let decode_rfc4648_url ?(no_padding=false) = decode ~no_padding ~ignore_newline:false ~ignore_unknown:false ~c62:'-' ~c63:'_'
+
+end

--- a/kxclib.ml
+++ b/kxclib.ml
@@ -1909,16 +1909,18 @@ module Jv = struct
 end
 
 module Base64 = struct
-  open struct
+
+  module InternalUtils = struct
     let int_A = int_of_char 'A'
     let int_Z = int_of_char 'Z'
     let int_a = int_of_char 'a'
     let int_z = int_of_char 'z'
     let int_0 = int_of_char '0'
     let int_9 = int_of_char '9'
-  end
+  end open InternalUtils
 
-  let encode ?(no_padding=false) ?(c62='+') ?(c63='/') input =
+  let encode ?(no_padding=false) ?(c62='+') ?(c63='/') ?(pad_char='=')
+        ?prefix ?sub:input_range input =
     let open Bytes in
     let c62, c63 = int_of_char c62, int_of_char c63 in
     let sixbit_to_char b =
@@ -1928,9 +1930,19 @@ module Base64 = struct
       else if b = 62 then c62
       else c63
     in
-    let len = length input in
-    let estimated_chars = (len / 3) * 4 + 4 (* worst case *) in
-    let output = create estimated_chars in
+    let iofs, ilen, itill = match input_range with
+      | None ->
+         let ilen = length input in
+         0, ilen, ilen
+      | Some (iofs, ilen) -> iofs, iofs+ilen, ilen in
+    let plen, prefix = match prefix with
+      | None -> 0, ignore
+      | Some p ->
+         let plen = String.length p in
+         plen, (fun out ->
+           iotaf' plen (fun i -> set out i (String.get p i))) in
+    let estimated_chars = (ilen / 3) * 4 + 4 (* worst case *) in
+    let output = create (plen + estimated_chars) in
     let write i o len =
       let set value o =
         set_uint8 output o (sixbit_to_char (value land 0x3f));
@@ -1952,7 +1964,7 @@ module Base64 = struct
             |> set b3 (* b3[2]..b3[7] *)
     in
     let rec go i o =
-      match len - i with
+      match itill - i with
       | 0 ->
         let pad_chars =
           match o mod 4 with
@@ -1963,15 +1975,18 @@ module Base64 = struct
           | _ -> failwith "impossible"
         in
         List.range 0 pad_chars
-        |> List.fold_left (fun o _ -> set output o '='; o+1) o
+        |> List.fold_left (fun o _ -> set output o pad_char; o+1) o
       | 1 -> `I |> write i o |> go (i+1)
       | 2 -> `S `I |> write i o |> go (i+2)
       | _ -> `S (`S `I) |> write i o |> go (i+3)
     in
-    let actual_chars = go 0 0 in
+    prefix output;
+    let actual_chars = go iofs plen in
     Bytes.sub output 0 actual_chars |> Bytes.to_string
 
-  let decode ?(no_padding=false) ?(ignore_newline=false) ?(ignore_unknown=false) ?(c62='+') ?(c63='/') input =
+  let decode ?(no_padding=false) ?(ignore_newline=false) ?(ignore_unknown=false)
+        ?(c62='+') ?(c63='/') ?(pad_char='=') ?prefix
+        ?sub:input_range input =
     let open Bytes in
     let c62, c63 = int_of_char c62, int_of_char c63 in
     let char_to_sixbit c =
@@ -1982,14 +1997,25 @@ module Base64 = struct
       else if c = c63 then Some 63
       else None
     in
-    let input = of_string input in
-    let len =
-      let len = length input in
-      if no_padding || (len mod 4) = 0 then len
+    let input, input_str = of_string input, input in
+    (match prefix with
+     | Some p when not (String.starts_with p input_str) ->
+        invalid_arg "Base64.decode: wrong prefix"
+     | _ -> ());
+    let iofs, ilen, itill =
+      let iofs = match prefix with
+        | Some p -> String.length p
+        | None -> 0 in
+      let iofs, itill = match input_range with
+        | None -> iofs, length input
+        | Some (iofs, ilen) -> iofs, iofs+ilen in
+      let ilen = itill - iofs in
+      if no_padding || (ilen mod 4) = 0 then
+        iofs, ilen, itill
       else invalid_arg "Base64.decode: wrong padding"
     in
     let output =
-      let estimated_bytes = (len / 4) * 3 + 2 in  (* worst case: 3n+2 bytes (= 4n+3 chars) *)
+      let estimated_bytes = (ilen / 4) * 3 + 2 in  (* worst case: 3n+2 bytes (= 4n+3 chars) *)
       create estimated_bytes
     in
     let read stack o =
@@ -2013,8 +2039,13 @@ module Base64 = struct
             set o ((s3 lsl 6) lor s4) (* s3[4] s3[5] s4[0]..[5] *)
           | _ -> failwith "impossible"
     in
+    let check_padding s =
+      match String.length s with
+      | slen when slen > 0 && slen <= 2 ->
+         iotafl slen (fun acc i -> acc && String.get s i = pad_char) true
+      | _ -> false in
     let rec go stack i o =
-      if i = len then read stack o
+      if i = itill then read stack o
       else
         let c = get_uint8 input i in
         match char_to_sixbit c with
@@ -2022,10 +2053,10 @@ module Base64 = struct
           begin match char_of_int c with
           | _ when ignore_unknown -> go stack (i+1) o
           | '\r' | '\n' when ignore_newline -> go stack (i+1) o
-          | '=' when not no_padding ->
-            let rest = sub_string input i (len - i) in
-            if rest = "=" || rest = "==" then read stack o
-            else invalid_arg' "Base64.decode: invalid char '=' at index %d" i
+          | c when c = pad_char && not no_padding ->
+            let rest = sub_string input i (itill - i) in
+            if check_padding rest then read stack o
+            else invalid_arg' "Base64.decode: invalid char '%c' at index %d" pad_char i
           | c -> invalid_arg' "Base64.decode: invalid char '%c' at index %d" c i
           end
         | Some s ->
@@ -2036,13 +2067,32 @@ module Base64 = struct
           else
             go stack (i+1) o
     in
-    let actual_bytes = go [] 0 0 in
+    let actual_bytes = go [] iofs 0 in
     Bytes.sub output 0 actual_bytes
 
-  let encode_rfc4648 = encode ~no_padding:false ~c62:'+' ~c63:'/'
-  let decode_rfc4648 = decode ~no_padding:false ~ignore_newline:false ~ignore_unknown:false ~c62:'+' ~c63:'/'
+  type base64_codec = (?sub:int * int -> bytes -> string) * (?sub:int * int -> string -> bytes)
 
-  let encode_rfc4648_url ?(no_padding=false) = encode ~no_padding ~c62:'-' ~c63:'_'
-  let decode_rfc4648_url ?(no_padding=false) = decode ~no_padding ~ignore_newline:false ~ignore_unknown:false ~c62:'-' ~c63:'_'
+  let base64_codec ?no_padding ?c62 ?c63 ?pad_char ?prefix
+        ?ignore_newline ?ignore_unknown
+        () : base64_codec =
+    let enc = encode ?no_padding ?c62 ?c63 ?pad_char ?prefix in
+    let dec = decode ?no_padding ?c62 ?c63 ?pad_char ?prefix ?ignore_newline ?ignore_unknown in
+    enc, dec
+
+  let encode_rfc4648' = encode ~no_padding:false ~c62:'+' ~c63:'/' ~pad_char:'='
+  let decode_rfc4648' ?(ignore_newline=true) =
+    decode ~no_padding:false ~c62:'+' ~c63:'/' ~pad_char:'='
+      ~ignore_newline ~ignore_unknown:false 
+
+  let encode_rfc4648_url' ?(no_padding=false) = encode ~no_padding ~c62:'-' ~c63:'_' ~pad_char:'='
+  let decode_rfc4648_url' ?(no_padding=false) =
+    decode ~no_padding ~c62:'-' ~c63:'_' ~pad_char:'='
+      ~ignore_newline:false ~ignore_unknown:false 
+
+  let encode_rfc4648 ?sub bytes = encode_rfc4648' ?sub bytes
+  let decode_rfc4648 ?sub str = decode_rfc4648' ?sub str
+
+  let encode_rfc4648_url ?sub bytes = encode_rfc4648_url' ?sub bytes
+  let decode_rfc4648_url ?sub str = decode_rfc4648_url' ?sub str
 
 end

--- a/unit_test/baselib_unit_tests.ml
+++ b/unit_test/baselib_unit_tests.ml
@@ -18,7 +18,7 @@ let seq_iteri n msgs () =
     an_array.(i) <- mk_msg i x in
   let expected = msgs in
   let actual = iteri f s; an_array in
-  check (array string) "seq_iteri" actual expected
+  check (array string) "seq_iteri" expected actual
 
 
 let seq_iteri_0 =
@@ -27,7 +27,7 @@ let seq_iteri_0 =
 
 let seq_range start end_exclusive expected () =
   let actual = Seq.range start end_exclusive |> Array.of_seq in
-  check (array int) "seq_range" actual expected
+  check (array int) "seq_range" expected actual
 
 
 let seq_range_0 = seq_range 3 7 [|3; 4; 5; 6|]
@@ -35,7 +35,7 @@ let seq_range_0 = seq_range 3 7 [|3; 4; 5; 6|]
 
 let seq_make tstbl n x expected () =
   let actual = Seq.make n x |> Array.of_seq in
-  check tstbl "seq_make" actual expected
+  check tstbl "seq_make" expected actual
 
 
 let seq_make_0 = seq_make (array int) 5 2 [|2; 2; 2; 2; 2|]
@@ -47,7 +47,7 @@ let seq_make_3 = seq_make (array float_testable) 0 3.14 ([||])
 let seq_take tstbl n org_lst expected_lst () =
   let actual = List.to_seq org_lst |> Seq.take n in
   let actual_lst = List.of_seq actual in
-  check tstbl "seq_take" actual_lst expected_lst
+  check tstbl "seq_take" expected_lst actual_lst
 
 
 let seq_take_0 = seq_take (list int) 2 [2; 3; 4] [2; 3]
@@ -57,7 +57,7 @@ let seq_take_1 = seq_take (list string) 0 ["A"; "B"; "C"] []
 let seq_drop tstbl n org_lst expected_lst () =
   let actual = List.to_seq org_lst |> Seq.drop n in
   let actual_lst = List.of_seq actual in
-  check tstbl "seq_drop" actual_lst expected_lst
+  check tstbl "seq_drop" expected_lst actual_lst
 
 
 let seq_drop_0 = seq_drop (list int) 2 [2; 3; 4] [4]
@@ -85,41 +85,94 @@ let stream_drop_0 = stream_drop (list int) 2 [2; 3; 4] [4]
 let stream_drop_1 = stream_drop (list string) 0 ["A"; "B"; "C"] ["A"; "B"; "C"]
 let stream_drop_2 = stream_drop (list string) 3 ["A"; "B"; "C"] []
 
+let base64_known () =
+  let cases = [
+    (* from RFC4648 *)
+    "", "";
+    "f", "Zg==";
+    "fo", "Zm8=";
+    "foo", "Zm9v";
+    "foob", "Zm9vYg==";
+    "fooba", "Zm9vYmE=";
+    "foobar", "Zm9vYmFy";
+
+    (* long strings *)
+    "hello, world", "aGVsbG8sIHdvcmxk";
+    "hello, world?!", "aGVsbG8sIHdvcmxkPyE=";
+    "hello, world.", "aGVsbG8sIHdvcmxkLg==";
+
+    (* very long strings *)
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna.",
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYS4=";
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQu";
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==";
+
+    (* bytes *)
+    "\xff", "/w==";
+    "\xff\xee", "/+4=";
+    "\xff\xee\xdd", "/+7d";
+    "\xff\xee\xdd\xcc", "/+7dzA==";
+    "\xff\xee\xdd\xcc\xbb", "/+7dzLs=";
+    "\xff\xee\xdd\xcc\xbb\xaa", "/+7dzLuq";
+    "\xff\xee\xdd\xcc\xbb\xaa\x99", "/+7dzLuqmQ==";
+    "\xff\xee\xdd\xcc\xbb\xaa\x99\x88", "/+7dzLuqmYg=";
+
+    (* edge cases *)
+    "\x00", "AA==";
+    "\x00\x00", "AAA=";
+    "\x00\x00\x00", "AAAA";
+    "\xff", "/w==";
+    "\xff\xff", "//8=";
+    "\xff\xff\xff", "////";
+  ] in
+  cases |> List.iter (fun (plain, code) ->
+    let expected_plain = Bytes.of_string plain in
+    let expected_code = code in
+    let actual_code = Base64.encode_rfc4648 expected_plain in
+    check string (sprintf "base64: encode '%s'" plain) expected_code actual_code;
+    let actual_plain = Base64.decode_rfc4648 expected_code in
+    check bytes (sprintf "base64: decode '%s'" code) expected_plain actual_plain
+  )
 
 let () =
   Printexc.record_backtrace true;
   run "Datecode_unit_tests" [
-      "trivial", [
-        test_case "trivial_case" `Quick trivial
-      ];
-      "seq_iteri", [
-          test_case "seq_iteri_0" `Quick seq_iteri_0
-      ];
-      "seq_range", [
-          test_case "seq_range_0" `Quick seq_range_0
-      ];
-      "seq_make", [
-          test_case "seq_make_0" `Quick seq_make_0;
-          test_case "seq_make_1" `Quick seq_make_1;
-          test_case "seq_make_2" `Quick seq_make_2;
-          test_case "seq_make_3" `Quick seq_make_3;
-      ];
-      "seq_take", [
-          test_case "seq_take_0" `Quick seq_take_0;
-          test_case "seq_take_1" `Quick seq_take_1
-      ];
-      "seq_drop", [
-          test_case "seq_drop_0" `Quick seq_drop_0;
-          test_case "seq_drop_1" `Quick seq_drop_1;
-          test_case "seq_drop_2" `Quick seq_drop_2
-      ];
-      "stream_take", [
-          test_case "stream_take_0" `Quick stream_take_0;
-          test_case "stream_take_1" `Quick stream_take_1
-      ];
-      "stream_drop", [
-          test_case "stream_drop_0" `Quick stream_drop_0;
-          test_case "stream_drop_1" `Quick stream_drop_1;
-          test_case "stream_drop_2" `Quick stream_drop_2
-      ]
+    "trivial", [
+      test_case "trivial_case" `Quick trivial
+    ];
+    "seq_iteri", [
+      test_case "seq_iteri_0" `Quick seq_iteri_0
+    ];
+    "seq_range", [
+      test_case "seq_range_0" `Quick seq_range_0
+    ];
+    "seq_make", [
+      test_case "seq_make_0" `Quick seq_make_0;
+      test_case "seq_make_1" `Quick seq_make_1;
+      test_case "seq_make_2" `Quick seq_make_2;
+      test_case "seq_make_3" `Quick seq_make_3;
+    ];
+    "seq_take", [
+      test_case "seq_take_0" `Quick seq_take_0;
+      test_case "seq_take_1" `Quick seq_take_1
+    ];
+    "seq_drop", [
+      test_case "seq_drop_0" `Quick seq_drop_0;
+      test_case "seq_drop_1" `Quick seq_drop_1;
+      test_case "seq_drop_2" `Quick seq_drop_2
+    ];
+    "stream_take", [
+      test_case "stream_take_0" `Quick stream_take_0;
+      test_case "stream_take_1" `Quick stream_take_1
+    ];
+    "stream_drop", [
+      test_case "stream_drop_0" `Quick stream_drop_0;
+      test_case "stream_drop_1" `Quick stream_drop_1;
+      test_case "stream_drop_2" `Quick stream_drop_2
+    ];
+    "base64", [
+      test_case "base64_known" `Quick base64_known;
     ]
+  ]

--- a/unit_test/baselib_unit_tests.ml
+++ b/unit_test/baselib_unit_tests.ml
@@ -86,54 +86,64 @@ let stream_drop_1 = stream_drop (list string) 0 ["A"; "B"; "C"] ["A"; "B"; "C"]
 let stream_drop_2 = stream_drop (list string) 3 ["A"; "B"; "C"] []
 
 let base64_known () =
+  let open Base64 in
+  let rfc4648_base64 = encode_rfc4648, decode_rfc4648 in
+  let rfc4648_base64url = encode_rfc4648_url, decode_rfc4648_url in
+  let prefixed = base64_codec() ~prefix:";base64," in
   let cases = [
     (* from RFC4648 *)
-    "", "";
-    "f", "Zg==";
-    "fo", "Zm8=";
-    "foo", "Zm9v";
-    "foob", "Zm9vYg==";
-    "fooba", "Zm9vYmE=";
-    "foobar", "Zm9vYmFy";
+    "", "", rfc4648_base64;
+    "f", "Zg==", rfc4648_base64;
+    "fo", "Zm8=", rfc4648_base64;
+    "foo", "Zm9v", rfc4648_base64;
+    "foob", "Zm9vYg==", rfc4648_base64;
+    "fooba", "Zm9vYmE=", rfc4648_base64;
+    "foobar", "Zm9vYmFy", rfc4648_base64;
 
     (* long strings *)
-    "hello, world", "aGVsbG8sIHdvcmxk";
-    "hello, world?!", "aGVsbG8sIHdvcmxkPyE=";
-    "hello, world.", "aGVsbG8sIHdvcmxkLg==";
+    "hello, world", "aGVsbG8sIHdvcmxk", rfc4648_base64;
+    "hello, world?!", "aGVsbG8sIHdvcmxkPyE=", rfc4648_base64;
+    "hello, world.", "aGVsbG8sIHdvcmxkLg==", rfc4648_base64;
 
     (* very long strings *)
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna.",
-    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYS4=";
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYS4=", rfc4648_base64;
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQu";
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQu", rfc4648_base64;
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==";
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==", rfc4648_base64;
 
     (* bytes *)
-    "\xff", "/w==";
-    "\xff\xee", "/+4=";
-    "\xff\xee\xdd", "/+7d";
-    "\xff\xee\xdd\xcc", "/+7dzA==";
-    "\xff\xee\xdd\xcc\xbb", "/+7dzLs=";
-    "\xff\xee\xdd\xcc\xbb\xaa", "/+7dzLuq";
-    "\xff\xee\xdd\xcc\xbb\xaa\x99", "/+7dzLuqmQ==";
-    "\xff\xee\xdd\xcc\xbb\xaa\x99\x88", "/+7dzLuqmYg=";
+    "\xff", "/w==", rfc4648_base64;
+    "\xff\xee", "/+4=", rfc4648_base64;
+    "\xff\xee\xdd", "/+7d", rfc4648_base64;
+    "\xff\xee\xdd\xcc", "/+7dzA==", rfc4648_base64;
+    "\xff\xee\xdd\xcc\xbb", "/+7dzLs=", rfc4648_base64;
+    "\xff\xee\xdd\xcc\xbb\xaa", "/+7dzLuq", rfc4648_base64;
+    "\xff\xee\xdd\xcc\xbb\xaa\x99", "/+7dzLuqmQ==", rfc4648_base64;
+    "\xff\xee\xdd\xcc\xbb\xaa\x99\x88", "/+7dzLuqmYg=", rfc4648_base64;
 
     (* edge cases *)
-    "\x00", "AA==";
-    "\x00\x00", "AAA=";
-    "\x00\x00\x00", "AAAA";
-    "\xff", "/w==";
-    "\xff\xff", "//8=";
-    "\xff\xff\xff", "////";
+    "\x00", "AA==", rfc4648_base64;
+    "\x00\x00", "AAA=", rfc4648_base64;
+    "\x00\x00\x00", "AAAA", rfc4648_base64;
+    "\xff", "/w==", rfc4648_base64;
+    "\xff\xff", "//8=", rfc4648_base64;
+    "\xff\xff\xff", "////", rfc4648_base64;
+
+    (* base64url *)
+    "\xff\xee\xdd\xcc", "_-7dzA==", rfc4648_base64url;
+
+    (* prefix *)
+    "\xff\xee\xdd\xcc", ";base64,/+7dzA==", prefixed;
   ] in
-  cases |> List.iter (fun (plain, code) ->
+  cases |> List.iter (fun (plain, code, ((enc, dec) : base64_codec)) ->
     let expected_plain = Bytes.of_string plain in
     let expected_code = code in
-    let actual_code = Base64.encode_rfc4648 expected_plain in
-    check string (sprintf "base64: encode '%s'" plain) expected_code actual_code;
-    let actual_plain = Base64.decode_rfc4648 expected_code in
-    check bytes (sprintf "base64: decode '%s'" code) expected_plain actual_plain
+    let actual_code = enc expected_plain in
+    check string (sprintf "base64: encode '%s' => %s" plain expected_code) expected_code actual_code;
+    let actual_plain = dec expected_code in
+    check bytes (sprintf "base64: decode '%s' => %s" code (String.escaped plain)) expected_plain actual_plain
   )
 
 let () =

--- a/unit_test/baselib_unit_tests.ml
+++ b/unit_test/baselib_unit_tests.ml
@@ -86,69 +86,67 @@ let stream_drop_1 = stream_drop (list string) 0 ["A"; "B"; "C"] ["A"; "B"; "C"]
 let stream_drop_2 = stream_drop (list string) 3 ["A"; "B"; "C"] []
 
 let base64_known () =
-  let open Base64 in
-  let rfc4648_base64 = mk_rfc4648 () in
-  let rfc4648_base64url = mk_rfc4648_url () in
+  let rfc4648 = (module Base64 : Base64.T) in
+  let rfc4648_url = (module Base64.Url : Base64.T) in
   let cases = [
     (* from RFC4648 *)
-    "", "", rfc4648_base64;
-    "f", "Zg==", rfc4648_base64;
-    "fo", "Zm8=", rfc4648_base64;
-    "foo", "Zm9v", rfc4648_base64;
-    "foob", "Zm9vYg==", rfc4648_base64;
-    "fooba", "Zm9vYmE=", rfc4648_base64;
-    "foobar", "Zm9vYmFy", rfc4648_base64;
+    "", "", rfc4648;
+    "f", "Zg==", rfc4648;
+    "fo", "Zm8=", rfc4648;
+    "foo", "Zm9v", rfc4648;
+    "foob", "Zm9vYg==", rfc4648;
+    "fooba", "Zm9vYmE=", rfc4648;
+    "foobar", "Zm9vYmFy", rfc4648;
 
     (* long strings *)
-    "hello, world", "aGVsbG8sIHdvcmxk", rfc4648_base64;
-    "hello, world?!", "aGVsbG8sIHdvcmxkPyE=", rfc4648_base64;
-    "hello, world.", "aGVsbG8sIHdvcmxkLg==", rfc4648_base64;
+    "hello, world", "aGVsbG8sIHdvcmxk", rfc4648;
+    "hello, world?!", "aGVsbG8sIHdvcmxkPyE=", rfc4648;
+    "hello, world.", "aGVsbG8sIHdvcmxkLg==", rfc4648;
 
     (* very long strings *)
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna.",
     "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYS4=",
-    rfc4648_base64;
+    rfc4648;
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
     "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQu",
-    rfc4648_base64;
+    rfc4648;
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==",
-    rfc4648_base64;
+    rfc4648;
 
     (* bytes *)
-    "\xff", "/w==", rfc4648_base64;
-    "\xff\xee", "/+4=", rfc4648_base64;
-    "\xff\xee\xdd", "/+7d", rfc4648_base64;
-    "\xff\xee\xdd\xcc", "/+7dzA==", rfc4648_base64;
-    "\xff\xee\xdd\xcc\xbb", "/+7dzLs=", rfc4648_base64;
-    "\xff\xee\xdd\xcc\xbb\xaa", "/+7dzLuq", rfc4648_base64;
-    "\xff\xee\xdd\xcc\xbb\xaa\x99", "/+7dzLuqmQ==", rfc4648_base64;
-    "\xff\xee\xdd\xcc\xbb\xaa\x99\x88", "/+7dzLuqmYg=", rfc4648_base64;
+    "\xff", "/w==", rfc4648;
+    "\xff\xee", "/+4=", rfc4648;
+    "\xff\xee\xdd", "/+7d", rfc4648;
+    "\xff\xee\xdd\xcc", "/+7dzA==", rfc4648;
+    "\xff\xee\xdd\xcc\xbb", "/+7dzLs=", rfc4648;
+    "\xff\xee\xdd\xcc\xbb\xaa", "/+7dzLuq", rfc4648;
+    "\xff\xee\xdd\xcc\xbb\xaa\x99", "/+7dzLuqmQ==", rfc4648;
+    "\xff\xee\xdd\xcc\xbb\xaa\x99\x88", "/+7dzLuqmYg=", rfc4648;
 
     (* edge cases *)
-    "\x00", "AA==", rfc4648_base64;
-    "\x00\x00", "AAA=", rfc4648_base64;
-    "\x00\x00\x00", "AAAA", rfc4648_base64;
-    "\xff", "/w==", rfc4648_base64;
-    "\xff\xff", "//8=", rfc4648_base64;
-    "\xff\xff\xff", "////", rfc4648_base64;
+    "\x00", "AA==", rfc4648;
+    "\x00\x00", "AAA=", rfc4648;
+    "\x00\x00\x00", "AAAA", rfc4648;
+    "\xff", "/w==", rfc4648;
+    "\xff\xff", "//8=", rfc4648;
+    "\xff\xff\xff", "////", rfc4648;
 
     (* base64url *)
-    "\xff\xee\xdd\xcc", "_-7dzA==", rfc4648_base64url;
+    "\xff\xee\xdd\xcc", "_-7dzA", rfc4648_url;
   ] in
-  cases |> List.iter (fun (plain, code, (t: t)) ->
+  cases |> List.iter (fun (plain, code, (module B64: Base64.T)) ->
     let expected_plain = Bytes.of_string plain in
     let expected_code = code in
-    let actual_code = t.encode expected_plain in
+    let actual_code = B64.encode expected_plain in
     check string (sprintf "base64: encode '%s' => %s" plain expected_code) expected_code actual_code;
-    let actual_plain = t.decode expected_code in
+    let actual_plain = B64.decode expected_code in
     check bytes (sprintf "base64: decode '%s' => %s" code (String.escaped plain)) expected_plain actual_plain
   )
 
 let base64_range () =
-  let open Base64 in
   let orig = Bytes.of_string "\xff\xee\xdd\xcc\xbb\xaa\x99\x88" in
-  let cases = [
+  let input_cases = [
     (* offset, len, expected_code *)
     0, 8, "/+7dzLuqmYg=";
     0, 7, "/+7dzLuqmQ==";
@@ -161,11 +159,23 @@ let base64_range () =
     3, 2, "zLs=";
     4, 0, "";
   ] in
-  cases |> List.iter (fun (offset, len, expected_code) ->
-    let actual_code = encode_rfc4648 ~offset ~len orig in
+  input_cases |> List.iter (fun (offset, len, expected_code) ->
+    let actual_code = Base64.encode ~offset ~len orig in
     check string
       (sprintf "base64: encode with range (offset=%d, len=%d) => '%s'" offset len expected_code)
       expected_code actual_code
+  );
+  let output_cases = [
+    (* code, offset, len, expected_plain *)
+    "data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==", 23, None, "Hello, World!";
+    "{'data': 'SGVsbG8sIFdvcmxkIQ=='}", 10, Some 20, "Hello, World!";
+  ] in
+  output_cases |> List.iter (fun (code, offset, len, expected_plain) ->
+    let actual_plain = Base64.decode ~offset ?len code in
+    check bytes
+      (sprintf "base64: decode '%s' with range (offset=%d, len=%s) => '%s'"
+        code offset (match len with None -> "None" | Some d -> sprintf "%d" d) expected_plain)
+      (Bytes.of_string expected_plain) actual_plain
   )
 
 let () =

--- a/unit_test/baselib_unit_tests.ml
+++ b/unit_test/baselib_unit_tests.ml
@@ -87,9 +87,8 @@ let stream_drop_2 = stream_drop (list string) 3 ["A"; "B"; "C"] []
 
 let base64_known () =
   let open Base64 in
-  let rfc4648_base64 = encode_rfc4648, decode_rfc4648 in
-  let rfc4648_base64url = encode_rfc4648_url, decode_rfc4648_url in
-  let prefixed = base64_codec() ~prefix:";base64," in
+  let rfc4648_base64 = mk_rfc4648 () in
+  let rfc4648_base64url = mk_rfc4648_url () in
   let cases = [
     (* from RFC4648 *)
     "", "", rfc4648_base64;
@@ -107,11 +106,14 @@ let base64_known () =
 
     (* very long strings *)
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna.",
-    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYS4=", rfc4648_base64;
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYS4=",
+    rfc4648_base64;
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQu", rfc4648_base64;
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQu",
+    rfc4648_base64;
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==", rfc4648_base64;
+    "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg==",
+    rfc4648_base64;
 
     (* bytes *)
     "\xff", "/w==", rfc4648_base64;
@@ -133,17 +135,37 @@ let base64_known () =
 
     (* base64url *)
     "\xff\xee\xdd\xcc", "_-7dzA==", rfc4648_base64url;
-
-    (* prefix *)
-    "\xff\xee\xdd\xcc", ";base64,/+7dzA==", prefixed;
   ] in
-  cases |> List.iter (fun (plain, code, ((enc, dec) : base64_codec)) ->
+  cases |> List.iter (fun (plain, code, (t: t)) ->
     let expected_plain = Bytes.of_string plain in
     let expected_code = code in
-    let actual_code = enc expected_plain in
+    let actual_code = t.encode expected_plain in
     check string (sprintf "base64: encode '%s' => %s" plain expected_code) expected_code actual_code;
-    let actual_plain = dec expected_code in
+    let actual_plain = t.decode expected_code in
     check bytes (sprintf "base64: decode '%s' => %s" code (String.escaped plain)) expected_plain actual_plain
+  )
+
+let base64_range () =
+  let open Base64 in
+  let orig = Bytes.of_string "\xff\xee\xdd\xcc\xbb\xaa\x99\x88" in
+  let cases = [
+    (* offset, len, expected_code *)
+    0, 8, "/+7dzLuqmYg=";
+    0, 7, "/+7dzLuqmQ==";
+    0, 6, "/+7dzLuq";
+    1, 7, "7t3Mu6qZiA==";
+    2, 6, "3cy7qpmI";
+    3, 5, "zLuqmYg=";
+    1, 6, "7t3Mu6qZ";
+    2, 4, "3cy7qg==";
+    3, 2, "zLs=";
+    4, 0, "";
+  ] in
+  cases |> List.iter (fun (offset, len, expected_code) ->
+    let actual_code = encode_rfc4648 ~offset ~len orig in
+    check string
+      (sprintf "base64: encode with range (offset=%d, len=%d) => '%s'" offset len expected_code)
+      expected_code actual_code
   )
 
 let () =
@@ -184,5 +206,6 @@ let () =
     ];
     "base64", [
       test_case "base64_known" `Quick base64_known;
+      test_case "base64_range" `Quick base64_range;
     ]
   ]


### PR DESCRIPTION
* configurable な encoder/decoder と，RFC4648 の base64 と base64_url に準拠した alias functions を実装
* RFC4648 base64 に関するテストを追加
  - これが一番 strict な config になっているので，こいつが通れば config をゆるくした場合でも通る（はず）
  - url は記号が変わってるだけなので割愛
* ついでに `check` の expected actual が全部逆だったので直した